### PR TITLE
make raster layer backward compatible

### DIFF
--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -6,6 +6,7 @@ Raster Layers
 from __future__ import annotations
 
 import copy
+import inspect
 import itertools
 import math
 import warnings
@@ -328,19 +329,46 @@ class RasterLayer(RasterBase):
                 row, col = cell.rowcol
                 cell._xy = rio.transform.xy(self.transform, row, col, offset="center")
 
-    def _initialize_cells(self, model: Model, cell_cls: type[Cell]):
+    def _initialize_cells(self, model: Model, cell_cls: type[Cell]) -> None:
+        try:
+            init_params = inspect.signature(self.cell_cls.__init__).parameters
+        except (TypeError, ValueError):
+            supports_legacy_pos_indices = False
+        else:
+            supports_legacy_pos_indices = (
+                "pos" in init_params and "indices" in init_params
+            )
+
+        if supports_legacy_pos_indices:
+
+            def make_cell(grid_x: int, grid_y: int, row_idx: int, col_idx: int, xy):
+                # Backward-compatible path for legacy signature:
+                # __init__(self, model, pos=None, indices=None, ...)
+                cell = self.cell_cls(
+                    model,
+                    pos=(grid_x, grid_y),
+                    indices=(row_idx, col_idx),
+                )
+                # Legacy constructor path does not accept xy.
+                cell._xy = xy
+                return cell
+        else:
+
+            def make_cell(grid_x: int, grid_y: int, row_idx: int, col_idx: int, xy):
+                return self.cell_cls(
+                    model,
+                    pos=(grid_x, grid_y),
+                    rowcol=(row_idx, col_idx),
+                    xy=xy,
+                )
+
         self.cells = []
         for grid_x in range(self.width):
             col: list[cell_cls] = []
             for grid_y in range(self.height):
                 row_idx, col_idx = self.height - grid_y - 1, grid_x
                 xy = rio.transform.xy(self.transform, row_idx, col_idx, offset="center")
-                cell = self.cell_cls(
-                    model,
-                    pos=(grid_x, grid_y),
-                    rowcol=(row_idx, col_idx),
-                    xy=xy,
-                )
+                cell = make_cell(grid_x, grid_y, row_idx, col_idx, xy)
                 col.append(cell)
             self.cells.append(col)
 

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -216,13 +216,13 @@ class Cell(Agent):
         Deprecated setter for `pos`.
         """
         # mesa Agent set pos to None by default
-        # comment out the warning for now
-        #
-        # warnings.warn(
-        #     "Cell.pos setter is deprecated and will be read-only in a future release.",
-        #     DeprecationWarning,
-        #     stacklevel=2,
-        # )
+        # avoid raising a warning when pos is set to None by the Agent constructor
+        if pos is not None:
+            warnings.warn(
+                "Cell.pos setter is deprecated and will be read-only in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # set the pos for backward compatibility
         # in the future, this will be removed because pos is read-only
@@ -317,7 +317,7 @@ class RasterLayer(RasterBase):
         super().__init__(width, height, crs, total_bounds)
         self.model = model
         self.cell_cls = cell_cls
-        self._initialize_cells(model, cell_cls)
+        self._initialize_cells()
         self._attributes = set()
         self._neighborhood_cache = {}
 
@@ -332,7 +332,7 @@ class RasterLayer(RasterBase):
                 row, col = cell.rowcol
                 cell._xy = rio.transform.xy(self.transform, row, col, offset="center")
 
-    def _initialize_cells(self, model: Model, cell_cls: type[Cell]) -> None:
+    def _initialize_cells(self) -> None:
         try:
             init_params = inspect.signature(self.cell_cls.__init__).parameters
         except (TypeError, ValueError):
@@ -348,7 +348,7 @@ class RasterLayer(RasterBase):
                 # Backward-compatible path for legacy signature:
                 # __init__(self, model, pos=None, indices=None, ...)
                 cell = self.cell_cls(
-                    model,
+                    self.model,
                     pos=(grid_x, grid_y),
                     indices=(row_idx, col_idx),
                 )
@@ -360,7 +360,7 @@ class RasterLayer(RasterBase):
             # or: __init__(self, model, **kwargs)
             def make_cell(grid_x: int, grid_y: int, row_idx: int, col_idx: int, xy):
                 return self.cell_cls(
-                    model,
+                    self.model,
                     pos=(grid_x, grid_y),
                     rowcol=(row_idx, col_idx),
                     xy=xy,
@@ -368,7 +368,7 @@ class RasterLayer(RasterBase):
 
         self.cells = []
         for grid_x in range(self.width):
-            col: list[cell_cls] = []
+            col: list[Cell] = []
             for grid_y in range(self.height):
                 row_idx, col_idx = self.height - grid_y - 1, grid_x
                 xy = rio.transform.xy(self.transform, row_idx, col_idx, offset="center")

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -217,7 +217,7 @@ class Cell(Agent):
         """
         # mesa Agent set pos to None by default
         # comment out the warning for now
-        # 
+        #
         # warnings.warn(
         #     "Cell.pos setter is deprecated and will be read-only in a future release.",
         #     DeprecationWarning,

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -215,14 +215,17 @@ class Cell(Agent):
         """
         Deprecated setter for `pos`.
         """
-        warnings.warn(
-            "Cell.pos setter is deprecated and will be read-only in a future release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        # mesa Agent set pos to None by default
+        # comment out the warning for now
+        # 
+        # warnings.warn(
+        #     "Cell.pos setter is deprecated and will be read-only in a future release.",
+        #     DeprecationWarning,
+        #     stacklevel=2,
+        # )
+
         # set the pos for backward compatibility
-        # in the future, this will be removed and raise an AttributeError,
-        # because pos is read-only
+        # in the future, this will be removed because pos is read-only
         self._pos = pos
 
     @property
@@ -349,11 +352,12 @@ class RasterLayer(RasterBase):
                     pos=(grid_x, grid_y),
                     indices=(row_idx, col_idx),
                 )
-                # Legacy constructor path does not accept xy.
+                # Legacy constructor path does not accept xy; set it manually.
                 cell._xy = xy
                 return cell
         else:
-
+            # New constructor path: __init__(self, model, pos=None, rowcol=None, xy=None, ...)
+            # or: __init__(self, model, **kwargs)
             def make_cell(grid_x: int, grid_y: int, row_idx: int, col_idx: int, xy):
                 return self.cell_cls(
                     model,


### PR DESCRIPTION
This is an attempt trying to make https://github.com/mesa/mesa-geo/pull/299 less breaking.

Previously in our gis examples, we demonstrated how to subclass `Cell`:

```python
class LakeCell(mesa_geo.Cell):
    def __init__(self, model, pos=None, indices=None):
        super().__init__(model, pos, indices)
        ...
```

But this will result in an error `TypeError: LakeCell.__init__() got an unexpected keyword argument 'rowcol'` with the changes in #299.

Therefore in https://github.com/mesa/mesa-examples/pull/320 we update our gis example to update `Cell` subclass to:

```python
class LakeCell(mesa_geo.Cell):
    def __init__(self, model=None, **kwargs):
        super().__init__(model, **kwargs)
        ...
```

To make it less breaking, in this PR we update the `_initialize_cells` method in RasterLayer so that it works with both the old and the new ways of subclassing `Cell`.

In addition, we also removed the deprecation warning for `cell.pos` since it inherits Mesa.Agent and its `pos` is set to `None` by default, trigging the warning (see https://github.com/mesa/mesa-examples/pull/320#issuecomment-3891998802).