### PR TITLE
feat: random coord sampling in cells

### DIFF
--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -171,7 +171,6 @@ class Cell(Agent):
 
     Deprecated:
         `Cell.indices` is deprecated. Use `Cell.rowcol` instead.
-        `Cell.pos` is deprecated. Use `Cell.grid_pos` instead.
     """
 
     _pos: Coordinate | None
@@ -213,7 +212,20 @@ class Cell(Agent):
 
     @pos.setter
     def pos(self, pos: Coordinate | None) -> None:
-        # mesa Agent sets pos to None by default
+        """
+        Deprecated setter for `pos`.
+        """
+        # mesa Agent set pos to None by default
+        # avoid raising a warning when pos is set to None by the Agent constructor
+        if pos is not None:
+            warnings.warn(
+                "Cell.pos setter is deprecated and will be read-only in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        # set the pos for backward compatibility
+        # in the future, this will be removed because pos is read-only
         self._pos = pos
 
     @property
@@ -563,19 +575,51 @@ class RasterLayer(RasterBase):
         """
         Generate random continuous (x, y) coordinates within a specific raster cell.
 
-        Exactly one of `cell`, `pos`, or `rowcol` must be provided.
-        """
-        provided = [arg for arg in [cell, pos, rowcol] if arg is not None]
-        if len(provided) != 1:
-            raise ValueError("Exactly one of cell, pos, or rowcol must be provided.")
+        Exactly one of ``cell``, ``pos``, or ``rowcol`` must be provided.
 
-        # Resolve to pixel coordinates (col, row)
+        :param Cell | None cell: Cell to sample from.
+        :param Coordinate | None pos: Grid coordinate in ``(grid_x, grid_y)``
+            format with origin at lower left.
+        :param Coordinate | None rowcol: Raster index in ``(row, col)`` format
+            with origin at upper left.
+        :return: Random continuous ``(x, y)`` coordinate within the selected
+            cell in CRS units.
+        :rtype: FloatCoordinate
+        :raises ValueError: If selector arguments are invalid or out of bounds.
+        """
+        provided = [
+            name
+            for name, arg in (("cell", cell), ("pos", pos), ("rowcol", rowcol))
+            if arg is not None
+        ]
+        if len(provided) != 1:
+            selected = ", ".join(provided) if provided else "none"
+            raise ValueError(
+                "Exactly one of ``cell``, ``pos``, or ``rowcol`` must be provided. "
+                f"Received: {selected}."
+            )
+
+        # Resolve to pixel coordinates (row, col)
         if cell is not None:
-            col, row = cell.pos
+            if cell.rowcol is None:
+                raise ValueError("`cell.rowcol` is None; cannot derive raster indices.")
+            row, col = cell.rowcol
         elif pos is not None:
-            col, row = pos
+            if self.out_of_bounds(pos):
+                raise ValueError(
+                    f"`pos` {pos} is out of bounds for raster with width={self.width} and "
+                    f"height={self.height}."
+                )
+            grid_x, grid_y = pos
+            row, col = self.height - grid_y - 1, grid_x
         else:
+            assert rowcol is not None
             row, col = rowcol
+            if not (0 <= row < self.height and 0 <= col < self.width):
+                raise ValueError(
+                    f"`rowcol` {(row, col)} is out of bounds for raster with "
+                    f"height={self.height} and width={self.width}."
+                )
 
         # Generate random fractional offsets [0.0, 1.0)
         u = self.model.random.random()

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -562,7 +562,7 @@ class RasterLayer(RasterBase):
     ) -> FloatCoordinate:
         """
         Generate random continuous (x, y) coordinates within a specific raster cell.
-        
+
         Exactly one of `cell`, `pos`, or `rowcol` must be provided.
         """
         provided = [arg for arg in [cell, pos, rowcol] if arg is not None]
@@ -583,7 +583,7 @@ class RasterLayer(RasterBase):
 
         # Map pixel space to continuous CRS space using Affine matrix
         x, y = self.transform * (col + u, row + v)
-        
+
         return x, y
 
     def iter_neighborhood(

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -205,40 +205,15 @@ class Cell(Agent):
         self._xy = xy
 
     @property
-    def grid_pos(self) -> Coordinate | None:
+    def pos(self) -> Coordinate | None:
         """
         Grid position in (grid_x, grid_y) format with origin at lower left of the grid.
         """
         return self._pos
 
-    @property
-    def pos(self) -> Coordinate | None:
-        """
-        Deprecated alias of `grid_pos`.
-        """
-        warnings.warn(
-            "Cell.pos is deprecated and will be removed in a future release. "
-            "Use Cell.grid_pos instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._pos
-
     @pos.setter
     def pos(self, pos: Coordinate | None) -> None:
-        """
-        Deprecated setter for `grid_pos`.
-        """
         # mesa Agent sets pos to None by default
-        # avoid raising a warning when pos is set to None by the Agent constructor
-        if pos is not None:
-            warnings.warn(
-                "Cell.pos is deprecated and will be removed in a future release. "
-                "Use Cell.grid_pos instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         self._pos = pos
 
     @property
@@ -578,27 +553,37 @@ class RasterLayer(RasterBase):
                     )
         return data
 
-    def get_random_coord(self, cell: Cell | Coordinate) -> FloatCoordinate:
+    def get_random_xy(
+        self,
+        cell: Cell | None = None,
+        *,
+        pos: Coordinate | None = None,
+        rowcol: Coordinate | None = None,
+    ) -> FloatCoordinate:
         """
-        Get a random geographic/projected coordinate within the boundaries of a given cell.
-
-        :param cell: The Cell object or its grid position (grid_x, grid_y).
-        :return: A random (x, y) coordinate tuple in the CRS units.
+        Generate random continuous (x, y) coordinates within a specific raster cell.
+        
+        Exactly one of `cell`, `pos`, or `rowcol` must be provided.
         """
-        if isinstance(cell, tuple):
-            cell = self.cells[cell[0]][cell[1]]
+        provided = [arg for arg in [cell, pos, rowcol] if arg is not None]
+        if len(provided) != 1:
+            raise ValueError("Exactly one of cell, pos, or rowcol must be provided.")
 
-        row, col = cell.rowcol
+        # Resolve to pixel coordinates (col, row)
+        if cell is not None:
+            col, row = cell.pos
+        elif pos is not None:
+            col, row = pos
+        else:
+            row, col = rowcol
 
-        # Generate random offsets within the 1x1 pixel bounds [0.0, 1.0)
-        # Using the model's random number generator ensures simulation reproducibility
+        # Generate random fractional offsets [0.0, 1.0)
         u = self.model.random.random()
         v = self.model.random.random()
 
-        # Apply the affine transform to map from pixel space to CRS geographic space.
-        # This matrix multiplication safely handles any spatial resolution, rotation, or shearing.
+        # Map pixel space to continuous CRS space using Affine matrix
         x, y = self.transform * (col + u, row + v)
-
+        
         return x, y
 
     def iter_neighborhood(

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -201,16 +201,23 @@ class RasterBase(GeoBase):
 
         assert xy is not None
         x_coord, y_coord = xy
-        min_x, min_y, max_x, max_y = self.total_bounds
-        # Treat boundary points as in-bounds for continuous CRS coordinates.
+        # Use inverse affine mapping so rotated/sheared rasters are handled
+        # correctly (total_bounds alone can include points outside coverage).
+        col, row = (~self.transform) * (x_coord, y_coord)
+        # Inverse-transform outputs floats; boundary points can land slightly
+        # outside [0, width]/[0, height] due to floating-point roundoff.
         tol = np.finfo(float).eps * max(
-            1.0, abs(min_x), abs(min_y), abs(max_x), abs(max_y)
+            1.0,
+            abs(col),
+            abs(row),
+            float(self.width),
+            float(self.height),
         )
         return (
-            x_coord < min_x - tol
-            or x_coord > max_x + tol
-            or y_coord < min_y - tol
-            or y_coord > max_y + tol
+            col < -tol
+            or col > self.width + tol
+            or row < -tol
+            or row > self.height + tol
         )
 
 

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -241,7 +241,6 @@ class Cell(Agent):
 
         self._pos = pos
 
-
     @property
     def indices(self) -> Coordinate | None:
         """
@@ -601,7 +600,6 @@ class RasterLayer(RasterBase):
         x, y = self.transform * (col + u, row + v)
 
         return x, y
-        
 
     def iter_neighborhood(
         self,
@@ -850,7 +848,6 @@ class RasterLayer(RasterBase):
         :param str driver: The GDAL driver to use for writing the raster file.
             Default is 'GTiff'. See GDAL docs at https://gdal.org/drivers/raster/index.html.
         """
-        
 
         data = self.get_raster(attr_name)
         with rio.open(

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -171,6 +171,7 @@ class Cell(Agent):
 
     Deprecated:
         `Cell.indices` is deprecated. Use `Cell.rowcol` instead.
+        `Cell.pos` is deprecated. Use `Cell.grid_pos` instead.
     """
 
     _pos: Coordinate | None
@@ -204,29 +205,42 @@ class Cell(Agent):
         self._xy = xy
 
     @property
-    def pos(self) -> Coordinate | None:
+    def grid_pos(self) -> Coordinate | None:
         """
         Grid position in (grid_x, grid_y) format with origin at lower left of the grid.
         """
         return self._pos
 
+    @property
+    def pos(self) -> Coordinate | None:
+        """
+        Deprecated alias of `grid_pos`.
+        """
+        warnings.warn(
+            "Cell.pos is deprecated and will be removed in a future release. "
+            "Use Cell.grid_pos instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._pos
+
     @pos.setter
     def pos(self, pos: Coordinate | None) -> None:
         """
-        Deprecated setter for `pos`.
+        Deprecated setter for `grid_pos`.
         """
-        # mesa Agent set pos to None by default
+        # mesa Agent sets pos to None by default
         # avoid raising a warning when pos is set to None by the Agent constructor
         if pos is not None:
             warnings.warn(
-                "Cell.pos setter is deprecated and will be read-only in a future release.",
+                "Cell.pos is deprecated and will be removed in a future release. "
+                "Use Cell.grid_pos instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
 
-        # set the pos for backward compatibility
-        # in the future, this will be removed because pos is read-only
         self._pos = pos
+
 
     @property
     def indices(self) -> Coordinate | None:

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -201,9 +201,13 @@ class RasterBase(GeoBase):
 
         assert xy is not None
         x_coord, y_coord = xy
+        if not (np.isfinite(x_coord) and np.isfinite(y_coord)):
+            return True
         # Use inverse affine mapping so rotated/sheared rasters are handled
         # correctly (total_bounds alone can include points outside coverage).
         col, row = (~self.transform) * (x_coord, y_coord)
+        if not (np.isfinite(col) and np.isfinite(row)):
+            return True
         # Inverse-transform outputs floats; boundary points can land slightly
         # outside [0, width]/[0, height] due to floating-point roundoff.
         tol = np.finfo(float).eps * max(

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -579,6 +579,30 @@ class RasterLayer(RasterBase):
                     )
         return data
 
+    def get_random_coord(self, cell: Cell | Coordinate) -> FloatCoordinate:
+        """
+        Get a random geographic/projected coordinate within the boundaries of a given cell.
+
+        :param cell: The Cell object or its grid position (grid_x, grid_y).
+        :return: A random (x, y) coordinate tuple in the CRS units.
+        """
+        if isinstance(cell, tuple):
+            cell = self.cells[cell[0]][cell[1]]
+
+        row, col = cell.rowcol
+
+        # Generate random offsets within the 1x1 pixel bounds [0.0, 1.0)
+        # Using the model's random number generator ensures simulation reproducibility
+        u = self.model.random.random()
+        v = self.model.random.random()
+
+        # Apply the affine transform to map from pixel space to CRS geographic space.
+        # This matrix multiplication safely handles any spatial resolution, rotation, or shearing.
+        x, y = self.transform * (col + u, row + v)
+
+        return x, y
+        
+
     def iter_neighborhood(
         self,
         pos: Coordinate,
@@ -826,6 +850,7 @@ class RasterLayer(RasterBase):
         :param str driver: The GDAL driver to use for writing the raster file.
             Default is 'GTiff'. See GDAL docs at https://gdal.org/drivers/raster/index.html.
         """
+        
 
         data = self.get_raster(attr_name)
         with rio.open(

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -653,7 +653,7 @@ class RasterLayer(RasterBase):
             if cell.rowcol is None:
                 raise ValueError("`cell.rowcol` is None; cannot derive raster indices.")
             row, col = cell.rowcol
-            if not (0 <= row < self.height and 0 <= col < self.width):
+            if self.out_of_bounds(rowcol=(row, col)):
                 raise ValueError(
                     f"`cell.rowcol` {(row, col)} is out of bounds for raster with "
                     f"height={self.height} and width={self.width}."
@@ -669,7 +669,7 @@ class RasterLayer(RasterBase):
         else:
             assert rowcol is not None
             row, col = rowcol
-            if not (0 <= row < self.height and 0 <= col < self.width):
+            if self.out_of_bounds(rowcol=(row, col)):
                 raise ValueError(
                     f"`rowcol` {(row, col)} is out of bounds for raster with "
                     f"height={self.height} and width={self.width}."

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -152,17 +152,66 @@ class RasterBase(GeoBase):
     def to_crs(self, crs, inplace=False) -> RasterBase | None:
         raise NotImplementedError
 
-    def out_of_bounds(self, pos: Coordinate) -> bool:
+    def out_of_bounds(
+        self,
+        pos: Coordinate | None = None,
+        *,
+        rowcol: Coordinate | None = None,
+        xy: FloatCoordinate | None = None,
+    ) -> bool:
         """
-        Determines whether position is off the grid.
+        Determine whether a coordinate is outside the raster extent.
 
-        :param Coordinate pos: Position to check.
-        :return: True if position is off the grid, False otherwise.
+        Exactly one selector must be provided.
+
+        :param Coordinate | None pos: Grid position in ``(grid_x, grid_y)`` format
+            with origin at lower left.
+        :param Coordinate | None rowcol: Raster indices in ``(row, col)`` format
+            with origin at upper left.
+        :param FloatCoordinate | None xy: Continuous ``(x, y)`` coordinate in CRS units.
+        :return: True if the selected coordinate is off the raster, False otherwise.
         :rtype: bool
+        :raises ValueError: If selector arguments are invalid.
         """
 
-        x, y = pos
-        return x < 0 or x >= self.width or y < 0 or y >= self.height
+        provided = [
+            name
+            for name, arg in (("pos", pos), ("rowcol", rowcol), ("xy", xy))
+            if arg is not None
+        ]
+        if len(provided) != 1:
+            selected = ", ".join(provided) if provided else "none"
+            raise ValueError(
+                "Exactly one of ``pos``, ``rowcol``, or ``xy`` must be provided. "
+                f"Received: {selected}."
+            )
+
+        if pos is not None:
+            grid_x, grid_y = pos
+            return (
+                grid_x < 0
+                or grid_x >= self.width
+                or grid_y < 0
+                or grid_y >= self.height
+            )
+
+        if rowcol is not None:
+            row, col = rowcol
+            return row < 0 or row >= self.height or col < 0 or col >= self.width
+
+        assert xy is not None
+        x_coord, y_coord = xy
+        min_x, min_y, max_x, max_y = self.total_bounds
+        # Treat boundary points as in-bounds for continuous CRS coordinates.
+        tol = np.finfo(float).eps * max(
+            1.0, abs(min_x), abs(min_y), abs(max_x), abs(max_y)
+        )
+        return (
+            x_coord < min_x - tol
+            or x_coord > max_x + tol
+            or y_coord < min_y - tol
+            or y_coord > max_y + tol
+        )
 
 
 class Cell(Agent):
@@ -604,6 +653,11 @@ class RasterLayer(RasterBase):
             if cell.rowcol is None:
                 raise ValueError("`cell.rowcol` is None; cannot derive raster indices.")
             row, col = cell.rowcol
+            if not (0 <= row < self.height and 0 <= col < self.width):
+                raise ValueError(
+                    f"`cell.rowcol` {(row, col)} is out of bounds for raster with "
+                    f"height={self.height} and width={self.width}."
+                )
         elif pos is not None:
             if self.out_of_bounds(pos):
                 raise ValueError(

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -342,6 +342,32 @@ class TestRasterLayer(unittest.TestCase):
         )
         self.assertEqual(tr_cell.xy, expected_xy)
 
+    def test_get_random_xy_selector_equivalence(self):
+        cell = self.raster_layer.cells[1][2]
+
+        self.model.random.seed(19)
+        xy_from_cell = self.raster_layer.get_random_xy(cell=cell)
+        self.model.random.seed(19)
+        xy_from_pos = self.raster_layer.get_random_xy(pos=(1, 2))
+        self.model.random.seed(19)
+        xy_from_rowcol = self.raster_layer.get_random_xy(rowcol=(0, 1))
+
+        self.assertEqual(xy_from_cell, xy_from_pos)
+        self.assertEqual(xy_from_pos, xy_from_rowcol)
+
+    def test_get_random_xy_raises_for_out_of_bounds_pos(self):
+        with self.assertRaises(ValueError):
+            self.raster_layer.get_random_xy(pos=(self.raster_layer.width, 0))
+
+    def test_get_random_xy_raises_for_out_of_bounds_rowcol(self):
+        with self.assertRaises(ValueError):
+            self.raster_layer.get_random_xy(rowcol=(self.raster_layer.height, 0))
+
+    def test_get_random_xy_raises_for_cell_without_rowcol(self):
+        detached_cell = mg.Cell(self.model, pos=(0, 0), rowcol=None)
+        with self.assertRaises(ValueError):
+            self.raster_layer.get_random_xy(cell=detached_cell)
+
     def test_cell_xy_updates_after_to_crs(self):
         original_xy = self.raster_layer.cells[0][0].xy
         transformed_layer = self.raster_layer.to_crs("epsg:3857")
@@ -434,21 +460,3 @@ class TestRasterLayer(unittest.TestCase):
                 for idx in range(data.shape[0])
             )
         )
-
-    def test_get_random_xy(self):
-        from mesa import Model
-
-        from mesa_geo.raster_layers import RasterLayer
-
-        m = Model()
-        m.random.seed(42)  # Ensure deterministic tests
-
-        # 10x10 grid, CRS bounds from 0 to 10
-        r = RasterLayer(10, 10, "EPSG:4326", [0, 0, 10, 10], m)
-
-        # Test using `pos` kwargs
-        x, y = r.get_random_xy(pos=(0, 0))
-
-        # Cell (0,0) bounds are x: [0, 1], y: [0, 1]
-        assert 0.0 <= x <= 1.0
-        assert 0.0 <= y <= 1.0

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -434,3 +434,21 @@ class TestRasterLayer(unittest.TestCase):
                 for idx in range(data.shape[0])
             )
         )
+    
+
+    def test_get_random_xy(self):
+        from mesa import Model
+        from mesa_geo.raster_layers import RasterLayer
+
+        m = Model()
+        m.random.seed(42) # Ensure deterministic tests
+        
+        # 10x10 grid, CRS bounds from 0 to 10
+        r = RasterLayer(10, 10, "EPSG:4326", [0, 0, 10, 10], m)
+        
+        # Test using `pos` kwargs
+        x, y = r.get_random_xy(pos=(0, 0))
+        
+        # Cell (0,0) bounds are x: [0, 1], y: [0, 1]
+        assert 0.0 <= x <= 1.0
+        assert 0.0 <= y <= 1.0

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -404,6 +404,21 @@ class TestRasterLayer(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.raster_layer.out_of_bounds((0, 0), xy=self.raster_layer.cells[0][0].xy)
 
+    def test_out_of_bounds_xy_respects_sheared_transform_coverage(self):
+        sheared_layer = mg.RasterLayer(
+            width=2,
+            height=2,
+            crs="epsg:4326",
+            total_bounds=[0.0, 0.0, 4.0, 2.0],
+            model=self.model,
+        )
+        sheared_layer._transform = rio.transform.Affine(1.0, 1.0, 0.0, 0.0, 1.0, 0.0)
+
+        # Inside bbox but outside the sheared raster footprint.
+        self.assertTrue(sheared_layer.out_of_bounds(xy=(0.5, 1.5)))
+        # Inside the raster footprint.
+        self.assertFalse(sheared_layer.out_of_bounds(xy=(1.5, 0.5)))
+
     def test_cell_xy_updates_after_to_crs(self):
         original_xy = self.raster_layer.cells[0][0].xy
         transformed_layer = self.raster_layer.to_crs("epsg:3857")

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -434,21 +434,21 @@ class TestRasterLayer(unittest.TestCase):
                 for idx in range(data.shape[0])
             )
         )
-    
 
     def test_get_random_xy(self):
         from mesa import Model
+
         from mesa_geo.raster_layers import RasterLayer
 
         m = Model()
-        m.random.seed(42) # Ensure deterministic tests
-        
+        m.random.seed(42)  # Ensure deterministic tests
+
         # 10x10 grid, CRS bounds from 0 to 10
         r = RasterLayer(10, 10, "EPSG:4326", [0, 0, 10, 10], m)
-        
+
         # Test using `pos` kwargs
         x, y = r.get_random_xy(pos=(0, 0))
-        
+
         # Cell (0,0) bounds are x: [0, 1], y: [0, 1]
         assert 0.0 <= x <= 1.0
         assert 0.0 <= y <= 1.0

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -368,6 +368,42 @@ class TestRasterLayer(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.raster_layer.get_random_xy(cell=detached_cell)
 
+    def test_get_random_xy_raises_for_cell_with_out_of_bounds_rowcol(self):
+        detached_cell = mg.Cell(
+            self.model, pos=(0, 0), rowcol=(self.raster_layer.height, 0)
+        )
+        with self.assertRaises(ValueError):
+            self.raster_layer.get_random_xy(cell=detached_cell)
+
+    def test_out_of_bounds_accepts_pos_rowcol_and_xy(self):
+        self.assertFalse(self.raster_layer.out_of_bounds((0, 0)))
+        self.assertTrue(self.raster_layer.out_of_bounds((self.raster_layer.width, 0)))
+
+        self.assertFalse(self.raster_layer.out_of_bounds(rowcol=(0, 0)))
+        self.assertTrue(
+            self.raster_layer.out_of_bounds(rowcol=(self.raster_layer.height, 0))
+        )
+
+        min_x, min_y, max_x, max_y = self.raster_layer.total_bounds
+        self.assertFalse(self.raster_layer.out_of_bounds(xy=(min_x, min_y)))
+        self.assertFalse(self.raster_layer.out_of_bounds(xy=(min_x, max_y)))
+        self.assertFalse(self.raster_layer.out_of_bounds(xy=(max_x, min_y)))
+        self.assertFalse(self.raster_layer.out_of_bounds(xy=(max_x, max_y)))
+
+        delta_x, delta_y = self.raster_layer.resolution
+        self.assertTrue(self.raster_layer.out_of_bounds(xy=(max_x + delta_x, min_y)))
+        self.assertTrue(self.raster_layer.out_of_bounds(xy=(min_x, min_y - delta_y)))
+
+    def test_out_of_bounds_raises_for_invalid_selector_combinations(self):
+        with self.assertRaises(ValueError):
+            self.raster_layer.out_of_bounds()
+
+        with self.assertRaises(ValueError):
+            self.raster_layer.out_of_bounds((0, 0), rowcol=(0, 0))
+
+        with self.assertRaises(ValueError):
+            self.raster_layer.out_of_bounds((0, 0), xy=self.raster_layer.cells[0][0].xy)
+
     def test_cell_xy_updates_after_to_crs(self):
         original_xy = self.raster_layer.cells[0][0].xy
         transformed_layer = self.raster_layer.to_crs("epsg:3857")

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -419,6 +419,12 @@ class TestRasterLayer(unittest.TestCase):
         # Inside the raster footprint.
         self.assertFalse(sheared_layer.out_of_bounds(xy=(1.5, 0.5)))
 
+    def test_out_of_bounds_xy_rejects_non_finite_values(self):
+        self.assertTrue(self.raster_layer.out_of_bounds(xy=(np.nan, 0.0)))
+        self.assertTrue(self.raster_layer.out_of_bounds(xy=(0.0, np.nan)))
+        self.assertTrue(self.raster_layer.out_of_bounds(xy=(np.inf, 0.0)))
+        self.assertTrue(self.raster_layer.out_of_bounds(xy=(0.0, -np.inf)))
+
     def test_cell_xy_updates_after_to_crs(self):
         original_xy = self.raster_layer.cells[0][0].xy
         transformed_layer = self.raster_layer.to_crs("epsg:3857")


### PR DESCRIPTION
### Summary
This PR implements `RasterLayer.get_random_coord(cell)` to generate random, continuous geographic/projected coordinates constrained within the spatial boundaries of a specific raster cell. 

### Motive
This directly addresses one of the core requests in **Issue #91** and the GSoC 2026 Ideas List for Mesa-Geo. When multiple agents occupy the same raster cell, they often need distinct, randomized spatial coordinates rather than stacking perfectly on the cell's center `xy` coordinate.

### Implementation
Instead of manually calculating offsets from the cell center (which can fail on rotated or sheared rasters), this implementation relies natively on `rasterio`'s `Affine` transformation matrix. 
- It generates random fractional offsets `u, v` in the range `[0.0, 1.0)`.
- It multiplies the `Affine` transform matrix by `(col + u, row + v)` to map the random pixel space directly into the continuous CRS space.
- It leverages `self.model.random.random()` to ensure the random sampling remains fully deterministic and respects the Mesa simulation seed.

### Usage Examples
```python
from mesa import Model
from mesa_geo.raster_layers import RasterLayer

m = Model()
# Create a 10x10 grid from 0 to 10 in CRS units
r = RasterLayer(10, 10, "EPSG:4326", [0, 0, 10, 10], m)

cell = r.cells[0][0]

print(cell.xy) 
# Output: (0.5, 0.5)

# Generate random geographic coordinates within the bounds of cell (0, 0)
print(r.get_random_coord(cell)) 
# Output: (0.848451972365314, 0.20513905377644015)
```


## Additional Notes
Verified locally. Supports passing either a `Cell` object directly or a tuple of `(grid_x, grid_y)` coordinates for convenience.