### PR TITLE
Drop Python 3.10, require Python 3.11+, add 3.14 testing

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -33,15 +33,17 @@ jobs:
       fail-fast: False
       matrix:
         os: [windows, ubuntu, macos]
-        python-version: ["3.12"]
+        python-version: ["3.14"]
         name: [""]
         include:
           - os: ubuntu
-            python-version: "3.11"
-          - os: ubuntu
-            python-version: "3.10"
+            python-version: "3.13"
           - os: ubuntu
             python-version: "3.12"
+          - os: ubuntu
+            python-version: "3.11"
+          - os: ubuntu
+            python-version: "3.14"
             pip-pre: "--pre"  # Installs pre-release versions of pip dependencies
             name: "Pre-release dependencies"  # Mainly to test Mesa pre-releases
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.12"
+        python-version: "3.14"
         cache: 'pip'
     - name: Install uv
       run: pip install uv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install dependencies
         run: pip install -U pip build wheel setuptools
       - name: Build distributions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   rev: v3.21.2
   hooks:
     - id: pyupgrade
-      args: [--py310-plus]
+      args: [--py311-plus]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0  # Use the ref you want to point at
   hooks:

--- a/mesa_geo/__init__.py
+++ b/mesa_geo/__init__.py
@@ -26,5 +26,5 @@ __all__ = [
 __title__ = "Mesa-Geo"
 __version__ = "0.9.3"
 __license__ = "Apache 2.0"
-_this_year = datetime.datetime.now(tz=datetime.timezone.utc).date().year
+_this_year = datetime.datetime.now(tz=datetime.UTC).date().year
 __copyright__ = f"Copyright {_this_year} Project Mesa Team"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "Mesa-Geo"
 description = "GIS Agent-based modeling (ABM) in Python"
 license = { text = "Apache 2.0" }
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
   { name = "Mesa Team", email = "maintainers@projectmesa.dev" },
 ]
@@ -29,9 +29,10 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Intended Audience :: Science/Research",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Development Status :: 3 - Alpha",
@@ -89,9 +90,9 @@ path = "mesa_geo/__init__.py"
 
 [tool.ruff]
 # See https://github.com/charliermarsh/ruff#rules for error code definitions.
-# Hardcode to Python 3.10.
+# Hardcode to Python 3.11.
 # Reminder to update mesa-examples if the value below is changed.
-target-version = "py310"
+target-version = "py311"
 extend-exclude = ["docs", "build"]
 
 lint.select = [


### PR DESCRIPTION
This PRs drop Python 3.10 support, which makes Mesa-geo require Python 3.11+ from now on forward. It also adds testing for Python 3.13 and 3.14.

Mesa itself already requires Python 3.12+, but since the geospatial stack is often a bit behind we can keep support for 3.11 for a while, I think.