### PR TITLE
Update Ruff hook id in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   rev: v0.14.14
   hooks:
     # Run the linter with fix argument.
-    - id: ruff
+    - id: ruff-check
       types_or: [ python, pyi, jupyter ]
       args: [--fix]  # This will enable automatic fixing of lint issues where possible.
     # Run the formatter.


### PR DESCRIPTION
Switch the Ruff pre-commit hook from the deprecated `ruff` legacy alias to the canonical `ruff-check` hook ID, aligning the configuration with upstream changes in `ruff-pre-commit` and eliminating the “legacy alias” warning while preserving existing linting and auto-fix behavior.

See astral-sh/ruff-pre-commit#124.