### PR TITLE
update issue/pr templates and link to mesa contributor guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/asking-help.md
+++ b/.github/ISSUE_TEMPLATE/asking-help.md
@@ -1,9 +1,0 @@
----
-name: Asking for help
-about: If you need help using Mesa-Geo, you should post in https://github.com/mesa/mesa-geo/discussions
----
-
-<!--
-    ATTENTION: Don't raise an issue here!
-    If you need help, ask in https://github.com/mesa/mesa-geo/discussions
--->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,8 @@ about: Let us know if something is broken on Mesa-Geo
 <!-- A clear and concise description of what you expected to happen -->
 
 **To Reproduce**
-<!-- Steps to reproduce the bug, or a link to a project where the bug is visible -->
+<!-- Steps to reproduce the bug, or a link to a project where the bug is visible
+Include a Minimal reproducible example: https://stackoverflow.com/help/minimal-reproducible-example -->
 
 **Additional context**
 <!--

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions, ideas, showcases and more
+    url: https://github.com/mesa/mesa-geo/discussions
+    about: Discuss Mesa-Geo, ask questions, share ideas, and showcase your projects

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -10,5 +10,8 @@ about: Suggest a new feature for Mesa-Geo
 **Describe the solution you'd like**
 <!-- A clear and concise description of what you want to happen. -->
 
+**Are you planning to open a PR for this?**
+<!-- For enhancements/new features, please wait for maintainer approval on this issue/discussion before opening a PR. -->
+
 **Additional context**
 <!-- Add any other context, links, etc. about the feature here. -->

--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -1,0 +1,23 @@
+> [!NOTE]
+> Use this template for bug fixes only. For enhancements/new features, use the feature template and get maintainer approval in an issue/discussion before opening a PR.
+
+### Pre-PR Checklist
+- [ ] This PR is a bug fix, not a new feature or enhancement.
+
+### Summary
+<!-- Provide a brief summary of the bug and its impact. -->
+
+### Bug / Issue
+<!-- Link to the related issue(s) and describe the bug. Include details like the context, what was expected, and what actually happened. -->
+
+### Implementation
+<!-- Describe the changes made to resolve the issue. Highlight any important parts of the code that were modified. -->
+
+### Testing
+<!-- Detail the testing performed to verify the fix. Include information on test cases, steps taken, and any relevant results.
+
+If you're fixing the visualisation, add before/after screenshots. -->
+
+### Additional Notes
+<!-- Add any additional information that may be relevant for the reviewers, such as potential side effects, dependencies, or related work.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,25 @@
+> [!IMPORTANT]
+> For enhancements and new features, include the issue/discussion where a maintainer approved this work before opening a PR. Unapproved feature/enhancement PRs may be closed.
+
+### Pre-PR Checklist
+- [ ] I linked an issue/discussion where a maintainer approved this enhancement/feature for implementation.
+
+### Approval Link
+<!-- Link to the issue/discussion comment where a maintainer confirmed this is ready for a PR. -->
+
+### Summary
+<!-- Provide a concise summary of the feature and its purpose. -->
+
+### Motive
+<!-- Explain the reasoning behind this feature. Include details on the problem it addresses or the enhancement it provides. -->
+
+### Implementation
+<!-- Describe how the feature was implemented. Include details on the approach taken, important decisions made, and code changes. -->
+
+### Usage Examples
+<!-- Provide code snippets or examples demonstrating how to use the new feature. Highlight key scenarios where this feature will be beneficial.
+
+If you're modifying the visualisation, add before/after screenshots. -->
+
+### Additional Notes
+<!-- Add any additional information that may be relevant for the reviewers, such as potential side effects, dependencies, or related work. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+Thanks for opening a PR! Please click the `Preview` tab and select a PR template:
+
+- [🐛 Bug fix](?expand=1&template=bug.md)
+- [🛠 Feature/enhancement](?expand=1&template=feature.md)
+
+Feature/enhancement PRs require prior maintainer approval in an issue or discussion before they are accepted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,13 @@ In no particular order, examples include:
 
 No contribution is too small. Although, contributions can be too big, so let's discuss via [Matrix] or via an [issue].
 
+> [!NOTE]
+> For Mesa-wide contribution process and development expectations, see [Mesa CONTRIBUTING].
+
 [Mesa discussions]: https://github.com/mesa/mesa/discussions
 [Matrix]: https://matrix.to/#/#project-mesa:matrix.org
 [issue]: https://github.com/mesa/mesa-geo/issues
+[Mesa CONTRIBUTING]: https://github.com/mesa/mesa/blob/main/CONTRIBUTING.md
 
 **To submit a contribution**
 


### PR DESCRIPTION
This PR updates issue/pr templates to be consistent with Mesa. Also adds a link to mesa contributor guide for broader contribution process and more information.