### PR TITLE
feat: introduce NumPy-backed storage for RasterLayer bands

### DIFF
--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -552,7 +552,7 @@ class RasterLayer(RasterBase):
             raise ValueError(f"Band '{name}' does not exist.")
         del self._data[name]
         self._attributes.discard(name)
-        
+
     def apply_raster(
         self, data: np.ndarray, attr_name: str | Sequence[str] | None = None
     ) -> None:

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -370,6 +370,7 @@ class RasterLayer(RasterBase):
     cells: list[list[Cell]]
     _neighborhood_cache: dict[Any, list[Coordinate]]
     _attributes: set[str]
+    _data: dict[str, np.ndarray]
 
     def __init__(
         self, width, height, crs, total_bounds, model, cell_cls: type[Cell] = Cell
@@ -377,9 +378,10 @@ class RasterLayer(RasterBase):
         super().__init__(width, height, crs, total_bounds)
         self.model = model
         self.cell_cls = cell_cls
-        self._initialize_cells()
         self._attributes = set()
+        self._data: dict[str, np.ndarray] = {}
         self._neighborhood_cache = {}
+        self._initialize_cells()
 
     def _update_transform(self) -> None:
         super()._update_transform()
@@ -518,6 +520,39 @@ class RasterLayer(RasterBase):
             for col in range(self.height):
                 yield self.cells[row][col], row, col  # cell, x, y
 
+    def create_band(self, name: str, default_value: float = 0.0) -> None:
+        if name in self._data:
+            raise ValueError(f"Band '{name}' already exists. Use remove_band() first.")
+        self._data[name] = np.full((self.height, self.width), default_value)
+        self._attributes.add(name)
+        for grid_x in range(self.width):
+            for grid_y in range(self.height):
+                setattr(self.cells[grid_x][grid_y], name, default_value)
+
+    def add_band(self, name: str, array: np.ndarray) -> None:
+        if array.shape != (self.height, self.width):
+            raise ValueError(
+                f"Array shape {array.shape} does not match raster shape "
+                f"({self.height}, {self.width})."
+            )
+        if name in self._data:
+            raise ValueError(f"Band '{name}' already exists. Use remove_band() first.")
+        self._data[name] = array.copy()
+        self._attributes.add(name)
+        for grid_x in range(self.width):
+            for grid_y in range(self.height):
+                setattr(
+                    self.cells[grid_x][grid_y],
+                    name,
+                    array[self.height - grid_y - 1, grid_x],
+                )
+
+    def remove_band(self, name: str) -> None:
+        if name not in self._data:
+            raise ValueError(f"Band '{name}' does not exist.")
+        del self._data[name]
+        self._attributes.discard(name)
+        
     def apply_raster(
         self, data: np.ndarray, attr_name: str | Sequence[str] | None = None
     ) -> None:
@@ -563,7 +598,7 @@ class RasterLayer(RasterBase):
                 names = [None] * num_bands
 
         def _default_attr_name() -> str:
-            base = f"attribute_{len(self.cell_cls.__dict__)}"
+            base = f"attribute_{len(self._attributes)}"
             if base not in self._attributes:
                 return base
             suffix = 1
@@ -576,6 +611,7 @@ class RasterLayer(RasterBase):
         for band_idx, name in enumerate(names):
             attr = _default_attr_name() if name is None else name
             self._attributes.add(attr)
+            self._data[attr] = data[band_idx].copy()
             for grid_x in range(self.width):
                 for grid_y in range(self.height):
                     setattr(
@@ -609,7 +645,7 @@ class RasterLayer(RasterBase):
                 )
         if attr_name is None:
             num_bands = len(self.attributes)
-            attr_names = self.attributes
+            attr_names = sorted(self.attributes)
         elif isinstance(attr_name, Sequence) and not isinstance(attr_name, str):
             num_bands = len(attr_name)
             attr_names = list(attr_name)

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -520,34 +520,64 @@ class RasterLayer(RasterBase):
             for col in range(self.height):
                 yield self.cells[row][col], row, col  # cell, x, y
 
-    def create_band(self, name: str, default_value: float = 0.0) -> None:
-        if name in self._data:
-            raise ValueError(f"Band '{name}' already exists. Use remove_band() first.")
-        self._data[name] = np.full((self.height, self.width), default_value)
-        self._attributes.add(name)
-        for grid_x in range(self.width):
-            for grid_y in range(self.height):
-                setattr(self.cells[grid_x][grid_y], name, default_value)
+    def set_band(
+        self, name: str, data: np.ndarray | float = 0.0
+    ) -> None:
+        """
+        Add a new band or overwrite an existing band.
 
-    def add_band(self, name: str, array: np.ndarray) -> None:
-        if array.shape != (self.height, self.width):
-            raise ValueError(
-                f"Array shape {array.shape} does not match raster shape "
-                f"({self.height}, {self.width})."
-            )
-        if name in self._data:
-            raise ValueError(f"Band '{name}' already exists. Use remove_band() first.")
-        self._data[name] = array.copy()
+        :param str name: Name of the band.
+        :param np.ndarray | float data: Either a 2D NumPy array of shape
+            (height, width) or a scalar fill value. Default is 0.0.
+        :raises ValueError: If data is an array with wrong shape.
+        """
+        if isinstance(data, np.ndarray):
+            if data.shape != (self.height, self.width):
+                raise ValueError(
+                    f"Array shape {data.shape} does not match raster shape "
+                    f"({self.height}, {self.width})."
+                )
+            self._data[name] = data.copy()
+        else:
+            self._data[name] = np.full((self.height, self.width), data)
         self._attributes.add(name)
         for grid_x in range(self.width):
             for grid_y in range(self.height):
                 setattr(
                     self.cells[grid_x][grid_y],
                     name,
-                    array[self.height - grid_y - 1, grid_x],
+                    self._data[name][self.height - grid_y - 1, grid_x],
                 )
 
+    def get_band(self, name: str) -> np.ndarray:
+        """
+        Return a single band as a 2D NumPy array.
+
+        :param str name: Name of the band.
+        :return: 2D NumPy array of shape (height, width).
+        :rtype: np.ndarray
+        :raises ValueError: If the band does not exist.
+        """
+        if name not in self._attributes:
+            raise ValueError(
+                f"Band '{name}' does not exist. "
+                f"Choose from {self._attributes}."
+            )
+        data = np.empty((self.height, self.width))
+        for grid_x in range(self.width):
+            for grid_y in range(self.height):
+                data[self.height - grid_y - 1, grid_x] = getattr(
+                    self.cells[grid_x][grid_y], name
+                )
+        return data
+
     def remove_band(self, name: str) -> None:
+        """
+        Remove a band from the raster layer.
+
+        :param str name: Name of the band to remove.
+        :raises ValueError: If the band does not exist.
+        """
         if name not in self._data:
             raise ValueError(f"Band '{name}' does not exist.")
         del self._data[name]

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -579,6 +579,9 @@ class RasterLayer(RasterBase):
             raise ValueError(f"Band '{name}' does not exist.")
         del self._data[name]
         self._attributes.discard(name)
+        for column in self.cells:
+            for cell in column:
+                delattr(cell, name)
 
     def apply_raster(
         self, data: np.ndarray, attr_name: str | Sequence[str] | None = None

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -520,9 +520,7 @@ class RasterLayer(RasterBase):
             for col in range(self.height):
                 yield self.cells[row][col], row, col  # cell, x, y
 
-    def set_band(
-        self, name: str, data: np.ndarray | float = 0.0
-    ) -> None:
+    def set_band(self, name: str, data: np.ndarray | float = 0.0) -> None:
         """
         Add a new band or overwrite an existing band.
 
@@ -560,8 +558,7 @@ class RasterLayer(RasterBase):
         """
         if name not in self._attributes:
             raise ValueError(
-                f"Band '{name}' does not exist. "
-                f"Choose from {self._attributes}."
+                f"Band '{name}' does not exist. Choose from {self._attributes}."
             )
         data = np.empty((self.height, self.width))
         for grid_x in range(self.width):

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -122,14 +122,26 @@ class TestRasterLayer(unittest.TestCase):
         result = self.raster_layer.get_band("slope")
         self.assertEqual(result[2, 0], 99.0)
 
+    def test_get_raster_reflects_direct_cell_mutation(self):
+        self.raster_layer.set_band("slope", 1.0)
+        self.raster_layer.cells[0][0].slope = 99.0
+
+        result = self.raster_layer.get_raster("slope")
+
+        self.assertEqual(result[0, 2, 0], 99.0)
+
     def test_get_band_missing_raises(self):
         with self.assertRaises(ValueError):
             self.raster_layer.get_band("nonexistent")
 
     def test_remove_band(self):
         self.raster_layer.set_band("slope")
+        self.assertTrue(hasattr(self.raster_layer.cells[0][0], "slope"))
+
         self.raster_layer.remove_band("slope")
+
         self.assertNotIn("slope", self.raster_layer.attributes)
+        self.assertFalse(hasattr(self.raster_layer.cells[0][0], "slope"))
         with self.assertRaises(ValueError):
             self.raster_layer.remove_band("slope")
 

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -106,8 +106,7 @@ class TestRasterLayer(unittest.TestCase):
         self.raster_layer.set_band("slope", 1.0)
         self.raster_layer.set_band("slope", 2.0)
         np.testing.assert_array_equal(
-            self.raster_layer.get_raster("slope"),
-            np.full((1, 3, 2), 2.0)
+            self.raster_layer.get_raster("slope"), np.full((1, 3, 2), 2.0)
         )
 
     def test_get_band(self):

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -98,8 +98,7 @@ class TestRasterLayer(unittest.TestCase):
         self.raster_layer.create_band("slope", default_value=1.0)
         self.assertIn("slope", self.raster_layer.attributes)
         np.testing.assert_array_equal(
-            self.raster_layer.get_raster("slope"),
-            np.ones((1, 3, 2))
+            self.raster_layer.get_raster("slope"), np.ones((1, 3, 2))
         )
         self.assertEqual(self.raster_layer.cells[0][0].slope, 1.0)
 
@@ -107,9 +106,7 @@ class TestRasterLayer(unittest.TestCase):
         array = np.array([[1, 2], [3, 4], [5, 6]], dtype=float)
         self.raster_layer.add_band("slope", array)
         self.assertIn("slope", self.raster_layer.attributes)
-        np.testing.assert_array_equal(
-            self.raster_layer.get_raster("slope")[0], array
-        )
+        np.testing.assert_array_equal(self.raster_layer.get_raster("slope")[0], array)
         self.assertEqual(self.raster_layer.cells[0][2].slope, array[0, 0])
         self.assertEqual(self.raster_layer.cells[0][0].slope, array[2, 0])
         with self.assertRaises(ValueError):

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -73,17 +73,7 @@ class TestRasterLayer(unittest.TestCase):
     def test_apply_raster(self):
         raster_data = np.array([[[1, 2], [3, 4], [5, 6]]])
         self.raster_layer.apply_raster(raster_data, attr_name="val")
-        """
-        (x, y) coordinates:
-        (0, 2), (1, 2)
-        (0, 1), (1, 1)
-        (0, 0), (1, 0)
 
-        values:
-        [[[1, 2],
-          [3, 4],
-          [5, 6]]]
-        """
         self.assertEqual(self.raster_layer.cells[0][1].val, 3)
         self.assertEqual(self.raster_layer.attributes, {"val"})
 
@@ -94,41 +84,55 @@ class TestRasterLayer(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.raster_layer.apply_raster(np.empty((1, 100, 100)))
 
-    def test_create_band(self):
-        self.raster_layer.create_band("slope", default_value=1.0)
+    def test_set_band_with_scalar(self):
+        self.raster_layer.set_band("slope", 1.0)
         self.assertIn("slope", self.raster_layer.attributes)
         np.testing.assert_array_equal(
             self.raster_layer.get_raster("slope"), np.ones((1, 3, 2))
         )
         self.assertEqual(self.raster_layer.cells[0][0].slope, 1.0)
 
-    def test_add_band(self):
+    def test_set_band_with_array(self):
         array = np.array([[1, 2], [3, 4], [5, 6]], dtype=float)
-        self.raster_layer.add_band("slope", array)
+        self.raster_layer.set_band("slope", array)
         self.assertIn("slope", self.raster_layer.attributes)
         np.testing.assert_array_equal(self.raster_layer.get_raster("slope")[0], array)
         self.assertEqual(self.raster_layer.cells[0][2].slope, array[0, 0])
         self.assertEqual(self.raster_layer.cells[0][0].slope, array[2, 0])
         with self.assertRaises(ValueError):
-            self.raster_layer.add_band("bad", np.zeros((10, 10)))
+            self.raster_layer.set_band("bad", np.zeros((10, 10)))
+
+    def test_set_band_overwrites_existing(self):
+        self.raster_layer.set_band("slope", 1.0)
+        self.raster_layer.set_band("slope", 2.0)
+        np.testing.assert_array_equal(
+            self.raster_layer.get_raster("slope"),
+            np.full((1, 3, 2), 2.0)
+        )
+
+    def test_get_band(self):
+        array = np.array([[1, 2], [3, 4], [5, 6]], dtype=float)
+        self.raster_layer.set_band("slope", array)
+        result = self.raster_layer.get_band("slope")
+        self.assertEqual(result.shape, (3, 2))
+        np.testing.assert_array_equal(result, array)
+
+    def test_get_band_reflects_direct_cell_mutation(self):
+        self.raster_layer.set_band("slope", 1.0)
+        self.raster_layer.cells[0][0].slope = 99.0
+        result = self.raster_layer.get_band("slope")
+        self.assertEqual(result[2, 0], 99.0)
+
+    def test_get_band_missing_raises(self):
+        with self.assertRaises(ValueError):
+            self.raster_layer.get_band("nonexistent")
 
     def test_remove_band(self):
-        self.raster_layer.create_band("slope")
+        self.raster_layer.set_band("slope")
         self.raster_layer.remove_band("slope")
         self.assertNotIn("slope", self.raster_layer.attributes)
         with self.assertRaises(ValueError):
             self.raster_layer.remove_band("slope")
-
-    def test_create_band_duplicate_raises(self):
-        self.raster_layer.create_band("slope")
-        with self.assertRaises(ValueError):
-            self.raster_layer.create_band("slope")
-
-    def test_add_band_duplicate_raises(self):
-        array = np.array([[1, 2], [3, 4], [5, 6]], dtype=float)
-        self.raster_layer.add_band("slope", array)
-        with self.assertRaises(ValueError):
-            self.raster_layer.add_band("slope", array)
 
     def test_apply_raster_single_band_attr_name_none(self):
         raster_data = np.array([[[7, 8], [9, 10], [11, 12]]])
@@ -225,17 +229,7 @@ class TestRasterLayer(unittest.TestCase):
     def test_get_raster(self):
         raster_data = np.array([[[1, 2], [3, 4], [5, 6]]])
         self.raster_layer.apply_raster(raster_data, attr_name="val")
-        """
-        (x, y) coordinates:
-        (0, 2), (1, 2)
-        (0, 1), (1, 1)
-        (0, 0), (1, 0)
 
-        values:
-        [[[1, 2],
-          [3, 4],
-          [5, 6]]]
-        """
         self.raster_layer.apply_raster(raster_data, attr_name="elevation")
         np.testing.assert_array_equal(
             self.raster_layer.get_raster(attr_name="elevation"), raster_data

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -94,6 +94,45 @@ class TestRasterLayer(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.raster_layer.apply_raster(np.empty((1, 100, 100)))
 
+    def test_create_band(self):
+        self.raster_layer.create_band("slope", default_value=1.0)
+        self.assertIn("slope", self.raster_layer.attributes)
+        np.testing.assert_array_equal(
+            self.raster_layer.get_raster("slope"),
+            np.ones((1, 3, 2))
+        )
+        self.assertEqual(self.raster_layer.cells[0][0].slope, 1.0)
+
+    def test_add_band(self):
+        array = np.array([[1, 2], [3, 4], [5, 6]], dtype=float)
+        self.raster_layer.add_band("slope", array)
+        self.assertIn("slope", self.raster_layer.attributes)
+        np.testing.assert_array_equal(
+            self.raster_layer.get_raster("slope")[0], array
+        )
+        self.assertEqual(self.raster_layer.cells[0][2].slope, array[0, 0])
+        self.assertEqual(self.raster_layer.cells[0][0].slope, array[2, 0])
+        with self.assertRaises(ValueError):
+            self.raster_layer.add_band("bad", np.zeros((10, 10)))
+
+    def test_remove_band(self):
+        self.raster_layer.create_band("slope")
+        self.raster_layer.remove_band("slope")
+        self.assertNotIn("slope", self.raster_layer.attributes)
+        with self.assertRaises(ValueError):
+            self.raster_layer.remove_band("slope")
+
+    def test_create_band_duplicate_raises(self):
+        self.raster_layer.create_band("slope")
+        with self.assertRaises(ValueError):
+            self.raster_layer.create_band("slope")
+
+    def test_add_band_duplicate_raises(self):
+        array = np.array([[1, 2], [3, 4], [5, 6]], dtype=float)
+        self.raster_layer.add_band("slope", array)
+        with self.assertRaises(ValueError):
+            self.raster_layer.add_band("slope", array)
+
     def test_apply_raster_single_band_attr_name_none(self):
         raster_data = np.array([[[7, 8], [9, 10], [11, 12]]])
         self.raster_layer.apply_raster(raster_data)


### PR DESCRIPTION
### Pre-PR Checklist
- [x] I linked an issue/discussion where a maintainer approved this enhancement/feature for implementation.

### Approval Link
Architecture approved in discussion #327. Implementation tracked in #329 .

### Summary
Introduces `self._data: dict[str, np.ndarray]` as the primary storage
backend for raster bands in `RasterLayer`. `get_raster()` now reads
directly from `self._data` instead of looping over individual `Cell`
objects. `apply_raster()`, `create_band()`, and `add_band()` write to
both `self._data` and cell attributes (dual write) for backward
compatibility. This is PR 1 of the GSoC 2026 RasterLayer refactor.

### Motive
`RasterLayer` currently retrieves band values via `getattr` on individual
`Cell` objects in O(N×M) loops. A 1000×1000 raster triggers one million
Python attribute lookups on every `get_raster()` call. PR #310
demonstrated a 98% runtime reduction from switching to a NumPy-backed
design. This PR introduces that backend without breaking any existing API.

### Implementation
- `self._data` and `self._attributes` initialized before
  `_initialize_cells()` to eliminate fragile ordering dependency
- `get_raster()` reads from `self._data` directly one array copy per
  band, no cell iteration
- `get_raster(None)` uses `sorted(self.attributes)` for deterministic
  band ordering across calls
- `apply_raster()`, `create_band()`, `add_band()` dual-write to
  `self._data` and cell attributes for backward compatibility with
  `to_image()` and user colormaps that read cell attributes directly
- `create_band()` and `add_band()` raise `ValueError` on duplicate band
  names instead of silently overwriting existing data
- `_default_attr_name()` counter fixed from `len(self.cell_cls.__dict__)`
  to `len(self._attributes)`, correct counter for auto-generated names
- `remove_band()` deletes from `_data` and `_attributes`: cell attribute
  cleanup deferred to next PR
- Coordinate mapping in `add_band()` uses
  `array[self.height - grid_y - 1, grid_x]`, consistent with
  `apply_raster()`
- 5 new tests covering `create_band`, `add_band`, `remove_band`,
  duplicate guard on both, and cell sync with coordinate-flip verification

### Usage Examples

```python
# Create a new band filled with a default value
raster_layer.create_band("slope", default_value=0.0)

# Attach an existing NumPy array as a band
raster_layer.add_band("elevation", some_array)

# Read a band: reads from _data directly, no cell iteration
data = raster_layer.get_raster("elevation")  # shape: (1, height, width)

# Remove a band
raster_layer.remove_band("slope")

# Duplicate band raises ValueError
raster_layer.create_band("slope")
raster_layer.create_band("slope")  # raises ValueError
```

### Additional Notes
77 tests pass. 1 pre-existing skip in `test_GIS_examples.py` unrelated
to this PR. `_initialize_cells()` and the `Cell` class are untouched in this
PR. in the next PR once I get the heads up will decouple `Cell` from `mesa.Agent` and remove all dual-write
overhead.