### PR TITLE
Backend array storage: make _data the single source of truth (RasterLayer refactor PR 2)

### DIFF
--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -229,6 +229,10 @@ class Cell(Agent):
     """
     Cells are containers of raster attributes, and are building blocks of `RasterLayer`.
 
+    Band data is stored in the parent RasterLayer's ``_data`` arrays.
+    Cell proxies attribute access into those arrays via ``__getattr__``
+    and ``__setattr__``.
+
     Deprecated:
         `Cell.indices` is deprecated. Use `Cell.rowcol` instead.
     """
@@ -245,6 +249,7 @@ class Cell(Agent):
         *,
         rowcol=None,
         xy=None,
+        _layer=None,
     ):
         """
         Initialize a cell.
@@ -256,12 +261,39 @@ class Cell(Agent):
         :param rowcol: Indices of the cell in (row, col) format.
             Origin is at upper left corner of the grid
         :param xy: Geographic/projected (x, y) coordinates of the cell center in the CRS.
+        :param _layer: The parent RasterLayer for band proxy access (internal use).
         """
+        self._layer = _layer
 
         super().__init__(model)
         self._pos = pos
         self._rowcol = indices if rowcol is None else rowcol
         self._xy = xy
+
+    def __getattr__(self, name: str):
+        try:
+            layer = object.__getattribute__(self, "_layer")
+        except AttributeError:
+            raise AttributeError(f"No attribute '{name}'") from None
+        if layer is not None and name in layer._data:
+            row, col = object.__getattribute__(self, "_rowcol")
+            return layer._data[name][row, col]
+        raise AttributeError(f"No band '{name}' on this layer")
+
+    def __setattr__(self, name: str, value):
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+            return
+        try:
+            layer = object.__getattribute__(self, "_layer")
+        except AttributeError:
+            object.__setattr__(self, name, value)
+            return
+        if layer is not None and name in layer._data:
+            row, col = object.__getattribute__(self, "_rowcol")
+            layer._data[name][row, col] = value
+            return
+        object.__setattr__(self, name, value)
 
     @property
     def pos(self) -> Coordinate | None:
@@ -275,8 +307,6 @@ class Cell(Agent):
         """
         Deprecated setter for `pos`.
         """
-        # mesa Agent set pos to None by default
-        # avoid raising a warning when pos is set to None by the Agent constructor
         if pos is not None:
             warnings.warn(
                 "Cell.pos setter is deprecated and will be read-only in a future release.",
@@ -284,8 +314,6 @@ class Cell(Agent):
                 stacklevel=2,
             )
 
-        # set the pos for backward compatibility
-        # in the future, this will be removed because pos is read-only
         self._pos = pos
 
     @property
@@ -333,6 +361,17 @@ class Cell(Agent):
 
     def step(self):
         pass
+
+    @property
+    def grid_pos(self) -> Coordinate:
+        """
+        Grid position in (grid_x, grid_y) format with origin at lower left.
+        Preferred replacement for the deprecated ``pos`` property.
+        """
+        row, col = self._rowcol
+        grid_x = col
+        grid_y = self._layer.height - row - 1
+        return grid_x, grid_y
 
 
 class RasterLayer(RasterBase):
@@ -407,25 +446,23 @@ class RasterLayer(RasterBase):
         if supports_legacy_pos_indices:
 
             def make_cell(grid_x: int, grid_y: int, row_idx: int, col_idx: int, xy):
-                # Backward-compatible path for legacy signature:
-                # __init__(self, model, pos=None, indices=None, ...)
                 cell = self.cell_cls(
                     self.model,
                     pos=(grid_x, grid_y),
                     indices=(row_idx, col_idx),
+                    _layer=self,
                 )
-                # Legacy constructor path does not accept xy; set it manually.
                 cell._xy = xy
                 return cell
         else:
-            # New constructor path: __init__(self, model, pos=None, rowcol=None, xy=None, ...)
-            # or: __init__(self, model, **kwargs)
+
             def make_cell(grid_x: int, grid_y: int, row_idx: int, col_idx: int, xy):
                 return self.cell_cls(
                     self.model,
                     pos=(grid_x, grid_y),
                     rowcol=(row_idx, col_idx),
                     xy=xy,
+                    _layer=self,
                 )
 
         self.cells = []
@@ -539,13 +576,6 @@ class RasterLayer(RasterBase):
         else:
             self._data[name] = np.full((self.height, self.width), data)
         self._attributes.add(name)
-        for grid_x in range(self.width):
-            for grid_y in range(self.height):
-                setattr(
-                    self.cells[grid_x][grid_y],
-                    name,
-                    self._data[name][self.height - grid_y - 1, grid_x],
-                )
 
     def get_band(self, name: str) -> np.ndarray:
         """
@@ -560,13 +590,7 @@ class RasterLayer(RasterBase):
             raise ValueError(
                 f"Band '{name}' does not exist. Choose from {self._attributes}."
             )
-        data = np.empty((self.height, self.width))
-        for grid_x in range(self.width):
-            for grid_y in range(self.height):
-                data[self.height - grid_y - 1, grid_x] = getattr(
-                    self.cells[grid_x][grid_y], name
-                )
-        return data
+        return self._data[name].copy()
 
     def remove_band(self, name: str) -> None:
         """
@@ -579,9 +603,6 @@ class RasterLayer(RasterBase):
             raise ValueError(f"Band '{name}' does not exist.")
         del self._data[name]
         self._attributes.discard(name)
-        for column in self.cells:
-            for cell in column:
-                delattr(cell, name)
 
     def apply_raster(
         self, data: np.ndarray, attr_name: str | Sequence[str] | None = None
@@ -642,13 +663,6 @@ class RasterLayer(RasterBase):
             attr = _default_attr_name() if name is None else name
             self._attributes.add(attr)
             self._data[attr] = data[band_idx].copy()
-            for grid_x in range(self.width):
-                for grid_y in range(self.height):
-                    setattr(
-                        self.cells[grid_x][grid_y],
-                        attr,
-                        data[band_idx, self.height - grid_y - 1, grid_x],
-                    )
 
     def get_raster(self, attr_name: str | Sequence[str] | None = None) -> np.ndarray:
         """
@@ -684,11 +698,7 @@ class RasterLayer(RasterBase):
             attr_names = [attr_name]
         data = np.empty((num_bands, self.height, self.width))
         for ind, name in enumerate(attr_names):
-            for grid_x in range(self.width):
-                for grid_y in range(self.height):
-                    data[ind, self.height - grid_y - 1, grid_x] = getattr(
-                        self.cells[grid_x][grid_y], name
-                    )
+            data[ind] = self._data[name]
         return data
 
     def get_random_xy(

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -362,17 +362,6 @@ class Cell(Agent):
     def step(self):
         pass
 
-    @property
-    def grid_pos(self) -> Coordinate:
-        """
-        Grid position in (grid_x, grid_y) format with origin at lower left.
-        Preferred replacement for the deprecated ``pos`` property.
-        """
-        row, col = self._rowcol
-        grid_x = col
-        grid_y = self._layer.height - row - 1
-        return grid_x, grid_y
-
 
 class RasterLayer(RasterBase):
     """

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -6,6 +6,7 @@ import warnings
 import mesa
 import numpy as np
 import rasterio as rio
+from mesa.agent import Agent
 
 import mesa_geo as mg
 
@@ -558,3 +559,52 @@ class TestRasterLayer(unittest.TestCase):
                 for idx in range(data.shape[0])
             )
         )
+
+    def test_agent_init_proxy_pos_interaction(self):
+        """Verify that Cell (as Agent subclass) constructs cleanly,
+        band proxy reads/writes through _data, and pos property still
+        behaves after Agent.__init__ sets self.pos = None."""
+        layer = self.raster_layer
+
+        band_data = np.arange(layer.height * layer.width, dtype=float).reshape(
+            layer.height, layer.width
+        )
+        layer.apply_raster(band_data[np.newaxis, :, :], attr_name="elevation")
+
+        cell = layer.cells[0][0]  # grid_x=0, grid_y=0
+        row, col = cell.rowcol
+        expected_val = band_data[row, col]
+        self.assertEqual(cell.elevation, expected_val)
+
+        cell.elevation = 999.0
+        self.assertEqual(layer._data["elevation"][row, col], 999.0)
+        self.assertEqual(cell.elevation, 999.0)
+
+        self.assertIsNotNone(cell.pos)
+        self.assertEqual(cell.pos, (0, 0))
+
+        self.assertIsInstance(cell, Agent)
+
+    def test_proxy_unknown_band_and_non_band_attr(self):
+        """Cell with a layer: reading an unknown band raises AttributeError,
+        and writing a non-band attribute falls back to normal instance storage."""
+        layer = self.raster_layer
+        cell = layer.cells[0][0]
+
+        with self.assertRaises(AttributeError):
+            _ = cell.not_a_band
+
+        cell.custom_attr = 123
+        self.assertEqual(cell.custom_attr, 123)
+        self.assertNotIn("custom_attr", layer._data)
+
+    def test_proxy_without_layer_reference(self):
+        """Cell with no _layer set falls back safely: reads raise AttributeError,
+        writes go to the instance dict (covers the except AttributeError branches)."""
+        cell = mg.Cell.__new__(mg.Cell)
+
+        with self.assertRaises(AttributeError):
+            _ = cell.anything
+
+        cell.plain = "ok"
+        self.assertEqual(cell.plain, "ok")


### PR DESCRIPTION
## Backend array storage: `_data` as the single source of truth

Part of #328. Follows #330 (merged).

This is PR 2 of the GSoC 2026 RasterLayer refactor. Its scope was narrowed following maintainer feedback: **`Cell` remains a `mesa.Agent` subclass** in this PR. Decoupling `Cell` from `Agent` has been deferred to a follow-up PR (to land alongside the cell-collection work).

### What this does

- Makes `RasterLayer._data` (a `dict[str, np.ndarray]`) the single source of truth for all band data.
- Removes the per-cell dual-write loops in `set_band`, `get_band`, `remove_band`, `apply_raster`, and `get_raster`, these now read from and write to `_data` directly instead of scattering/gathering across every cell.
- Makes `Cell` a thin proxy: `__getattr__`/`__setattr__` route band access (`cell.<band>`) directly into `self._layer._data[name][row, col]`. Cells no longer hold per-cell copies of band values.
- Wires `cell._layer` via a `_layer=` kwarg passed in `_initialize_cells`, preserving exact backward compatibility for both the legacy (`pos`/`indices`) and current `Cell` constructor signatures.
- Adds a regression test (`test_agent_init_proxy_pos_interaction`) confirming that the proxy safely ignores the default attribute assignments made by `Agent.__init__`, and that `pos` still behaves.
- Adds a `grid_pos` property on `Cell` as a preferred replacement for the deprecated `pos` (see open question below).

### Deferred to follow-up PRs

- **Decoupling `Cell` from `mesa.Agent`** : moved to a separate PR to land with cell collection, so activation isn't split between agents and the collection.
- **Examples update** : the GIS examples (`urban_growth`, `rainfall`, `population`) still assign band attributes (`self.<band> = None`) in `__init__` before their bands exist. This is handled in a separate mesa-examples PR, per the breaking-change workflow (release → bump `requirements.txt` → update examples).

### CI notes

- **`Test GIS examples` is expected to fail** on this branch. It's the deferred examples regression above, not an accidental break, it'll go green once the mesa-examples PR lands after the next release.
- All mesa-geo unit tests pass.

### Open questions for review

- **`grid_pos`**: kept here for now, but since `pos` deprecation is conceptually part of the cell redesign, happy to defer it to the decoupling PR if preferred.
- **Pre-assigned attribute shadowing**: a subclass that assigns `self.<band> = None` before the band exists will shadow the proxy (the value stays in `__dict__`). Following the discussion, this is being handled by investigating a migrate-and-erase approach rather than a `__getattribute__` safety net; noting it here so it's tracked in review..